### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ install:
   # Local
   - sudo apt-get install -qq luatex texlive-base texlive-luatex
   # Global 
-  - sudo apt-get install -qq pandoc latexmk texlive
+  - sudo apt-get install -qq pandoc latexmk texlive texlive-xetex
 
 script:
   # Already runs locally

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ install:
   - sudo apt-get install -qq luatex texlive-base texlive-luatex
 
 script:
-  - make4ht -v
+  - ./make4ht -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 
 install:
-  - sudo apt-get install -qq luatex texlive-base texlive-luatex
+  - sudo apt-get install -qq luatex texlive-base texlive-luatex pandoc
 
 script:
   # Already runs locally

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ install:
   # Local
   - sudo apt-get install -qq luatex texlive-base texlive-luatex
   # Global 
-  - sudo apt-get install -qq pandoc latexmk
+  - sudo apt-get install -qq pandoc latexmk texlive
 
 script:
   # Already runs locally

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 
 install:
-  - sudo apt-get install -qq luatex texlive-base texlive-luatex pandoc
+  # Local
+  - sudo apt-get install -qq luatex texlive-base texlive-luatex
+  # Global 
+  - sudo apt-get install -qq pandoc latexmk
 
 script:
   # Already runs locally

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,9 @@ install:
   - sudo apt-get install -qq luatex texlive-base texlive-luatex
 
 script:
+  # Already runs locally
   - ./make4ht -v
+  - make
+  - sudo make install
+  # Now runs globally
+  - make4ht -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+
+install:
+  - sudo apt-get install -qq luatex texlive-base texlive-luatex
+
+script:
+  - make4ht -v

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Introduction
 
-[![Build Status](https://travis-ci.org/richelbilderbeek/make4ht.svg?branch=master)](https://travis-ci.org/richelbilderbeek/make4ht)
-
 `make4ht` is a simple build system for `tex4ht`, \TeX\ to XML converter. It provides a command line tool
 that drive the conversion process. It also provides a library which can be used to create
 customized conversion tools. An example of such conversion tool is

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Introduction
 
+[![Build Status](https://travis-ci.org/richelbilderbeek/make4ht.svg?branch=master)](https://travis-ci.org/richelbilderbeek/make4ht)
+
 `make4ht` is a simple build system for `tex4ht`, \TeX\ to XML converter. It provides a command line tool
 that drive the conversion process. It also provides a library which can be used to create
 customized conversion tools. An example of such conversion tool is


### PR DESCRIPTION
I've added a Travis CI config file and a build status button.

Travis CI is a Continuous Integration (hence the name) service. With it, you can trigger a script (`.travis.yml`) that checks -after a Pull Request or commit- if the build is still passing. For me, having a build badge is an indicator of high quality software. The reason I've added is, is to see how I needed to install `make4ht`. There are many more reasons Travis CI is A Good Think (see e.g [a CppCast episode](http://cppcast.com/2017/06/richel-bilderbeek/) or [a Simplify C++ article](https://arne-mertz.de/2017/04/continuous-integration-travis-ci/) by me)

To make this work nicely as I did, you'll need to create a Travis CI account (can sign in with GitHub) and activate this reposity. Also replace `richelbilderbeek` in `README.md` by `michal-h21`. I'll be happy to help you get it working, but it works so simple with GitHub, I do not expect any problems.

I hope you like it. I sure do. 