### PR TITLE
Use a better method to preprocess R Markdown

### DIFF
--- a/extensions/make4ht-ext-preprocess_input.lua
+++ b/extensions/make4ht-ext-preprocess_input.lua
@@ -5,12 +5,13 @@ local mkutils = require "mkutils"
 
 local commands = {
   knitr = { command = 'Rscript -e "library(knitr); knit(\'${tex_file}\', output=\'${tmp_file}\')"'},
-  pandoc = { command = 'pandoc -f ${input_format} -s -o \'${tmp_file}\' -t latex \'${tex_file}\''}
+  pandoc = { command = 'pandoc -f ${input_format} -s -o \'${tmp_file}\' -t latex \'${tex_file}\''},
+  render = { command = 'Rscript -e "library(rmarkdown); render(\'${tex_file}\', output_file=\'${tmp_file}\')"'}
 }
 local filetypes = {
   rnw = {sequence = {"knitr"} },
   rtex = {sequence = {"knitr"}},
-  rmd = {sequence = {"knitr", "pandoc"}, options = {input_format = "markdown"}},
+  rmd = {sequence = {"render"}},
   rrst = {sequence = {"knitr", "pandoc"}, options = {input_format = "rst"}},
   md = {sequence = {"pandoc"}, options = {input_format = "markdown"}},
   rst = {sequence = {"pandoc"}, options = {input_format = "rst"}},


### PR DESCRIPTION
The `render()` function from the `rmarkdown` library will handle any needed calls to Knitr and Pandoc, including passing along more options to handle citations, templates, etc.

This change addresses #64 for `.rmd` files, but it is possible other filetypes may be better served with the provided `render` command as well.