### PR TITLE
feat: allow build directory for temporary files (Fixes #10)

### DIFF
--- a/extensions/make4ht-ext-staticsite.lua
+++ b/extensions/make4ht-ext-staticsite.lua
@@ -96,7 +96,11 @@ end
 
 local function copy_files(filename, par)
   local function prepare_path(dir, subdir)
-    local path = dir .. "/" .. subdir .. "/" .. filename
+    local f = filename
+    if par.builddir then
+        f = f:gsub("^" .. par.builddir .. "/", "")
+    end
+    local path = dir .. "/" .. subdir .. "/" .. f
     return path:gsub("//", "/")
   end
   -- get extension settings
@@ -151,7 +155,7 @@ function M.modify_build(make)
     --   print(match.pattern, match.params.outdir)
     -- end
     make:match("html?$", process)
-    make:match(".*", copy_files, {slug=slug})
+    make:match(".*", copy_files, {slug=slug, builddir=make.params.builddir})
   end)
 
   return make

--- a/formats/make4ht-odt.lua
+++ b/formats/make4ht-odt.lua
@@ -169,7 +169,7 @@ local lg_fonts_processed=false
 local patched_lg_fonts = {}
 local function fix_lgfile_fonts(ignored_name, params)
   -- this function is called from file match. we must use the name of the .lg file
-  local filename = params.input .. ".lg"
+  local filename = (params.builddir and params.builddir .. "/") .. main_name .. ".lg"
   if not lg_fonts_processed then
     local lines = {}
     -- default font_size

--- a/make4ht
+++ b/make4ht
@@ -128,7 +128,8 @@ make:match(".*",function(filename,par)
     return true
   end
 	log:info("outdir: "..outdir)
-	local outfilename = outdir .. filename
+    local outfilename = filename:gsub("^" .. par.builddir or "", "")
+	outfilename = outdir .. outfilename
 	mkutils.copy(filename,outfilename)
 	return true
 end)

--- a/make4ht-htlatex.lua
+++ b/make4ht-htlatex.lua
@@ -6,6 +6,9 @@ local Make = Make or {}
 -- this function reads the LaTeX log file and tries to detect fatal errors in the compilation
 local function testlogfile(par)
   local logfile = par.input .. ".log"
+  if par.builddir then
+      logfile = par.builddir .. "/" .. logfile
+  end
   local f = io.open(logfile,"r")
   if not f then
     log:warning("Make4ht: cannot open log file "..logfile)
@@ -40,7 +43,7 @@ Make.testlogfile = testlogfile
 --env.Make:add("htlatex", "${htlatex} ${latex_par} '\\\makeatletter\\def\\HCode{\\futurelet\\HCode\\HChar}\\def\\HChar{\\ifx\"\\HCode\\def\\HCode\"##1\"{\\Link##1}\\expandafter\\HCode\\else\\expandafter\\Link\\fi}\\def\\Link#1.a.b.c.{\\g@addto@macro\\@documentclasshook{\\RequirePackage[#1,html]{tex4ht}\\let\\HCode\\documentstyle\\def\\documentstyle{\\let\\documentstyle\\HCode\\expandafter\\def\\csname tex4ht\\endcsname{#1,html}\\def\\HCode####1{\\documentstyle[tex4ht,}\\@ifnextchar[{\\HCode}{\\documentstyle[tex4ht]}}}\\makeatother\\HCode '${config}${tex4ht_sty_par}'.a.b.c.\\input ' ${input}")
 
 -- template for calling LaTeX with tex4ht loaded
-Make.latex_command = "${htlatex} --interaction=${interaction} ${latex_par} '\\makeatletter"..
+Make.latex_command = "${htlatex} --interaction=${interaction} ${build_dir_arg} ${latex_par} '\\makeatletter"..
 "\\def\\HCode{\\futurelet\\HCode\\HChar}\\def\\HChar{\\ifx\"\\HCode"..
 "\\def\\HCode\"##1\"{\\Link##1}\\expandafter\\HCode\\else"..
 "\\expandafter\\Link\\fi}\\def\\Link#1.a.b.c.{"..
@@ -50,7 +53,7 @@ Make.latex_command = "${htlatex} --interaction=${interaction} ${latex_par} '\\ma
 "\\documentstyle[tex4ht]}}\\RequirePackage[#1,html]{tex4ht}${packages}}\\makeatother\\HCode ${tex4ht_sty_par}.a.b.c."..
 "\\input \"\\detokenize{${tex_file}}\"'"
 
-Make.plain_command = '${htlatex} --interaction=${interaction} ${latex_par}' ..
+Make.plain_command = '${htlatex} --interaction=${interaction} ${build_dir} ${latex_par}' ..
 "'\\def\\Link#1.a.b.c.{\\expandafter\\def\\csname tex4ht\\endcsname{\\expandafter\\def\\csname tex4ht\\endcsname{#1,html}\\input tex4ht.sty }}" ..
 "\\def\\HCode{\\futurelet\\HCode\\HChar}\\def\\HChar{\\ifx\"\\HCode\\def\\HCode\"##1\"{\\Link##1}\\expandafter\\HCode\\else\\expandafter\\Link\\fi}" ..
 "\\HCode ${tex4ht_sty_par}.a.b.c.\\input \"\\detokenize{${tex_file}}\"'"
@@ -67,7 +70,11 @@ function m.htlatex(par, latex_command)
     devnull = " > nul 2>&1"
   end
   par.interaction = par.interaction or "batchmode"
-  -- remove all terminal output from the batchmode 
+  if par.builddir then
+      par.build_dir_arg = "--output-directory=${builddir}" % par
+  else
+      par.build_dir_arg = ""
+  end
   if par.interaction == "batchmode" then
     command = command .. devnull
   end

--- a/make4ht-lib.lua
+++ b/make4ht-lib.lua
@@ -194,9 +194,10 @@ Make.run = function(self)
 			end
 		end
 	end
-	local lgfile = params.input and params.input .. ".lg" or nil 
+	local lgfile = params.input and params.input .. ".lg" or nil
+    local lgfile = (params.builddir and params.builddir .. "/") .. lgfile
 	if lgfile then
-   	self.lgfile = self.lgfile or mkutils.parse_lg(lgfile)
+   	self.lgfile = self.lgfile or mkutils.parse_lg(lgfile, params.builddir)
     local lg = self.lgfile
 		-- First convert images from lg files
 		self:image_convert(lg["images"])

--- a/mkparams.lua
+++ b/mkparams.lua
@@ -21,6 +21,7 @@ Available options:
                 possible values: tex4ht or lua4ht
   -c,--config (default xhtml) Custom config file
   -d,--output-dir (default nil)  Output directory
+  -B,--build-dir (default nil)  Build directory
   -e,--build-file (default nil)  If build file is different than `filename`.mk4
   -f,--format  (default html5)  Output file format
   -h,--help  Display this message
@@ -191,10 +192,18 @@ local function process_args(args)
 	local outdir = ""
 	local packages = ""
 
-	if  args["output-dir"] ~= "nil" then 
+	if  args["output-dir"] ~= "nil" then
 		outdir =  args["output-dir"]  or ""
 		outdir = outdir:gsub('\\','/')
 		outdir = outdir:gsub('/$','')
+	end
+
+	local builddir = ""
+
+	if  args["build-dir"] ~= "nil" then
+		builddir =  args["build-dir"]  or ""
+		builddir = builddir:gsub('\\','/')
+		builddir = builddir:gsub('/$','')
 	end
 
   -- make4ht now requires UTF-8 output, because of DOM filters
@@ -274,7 +283,7 @@ local function process_args(args)
 	local parameters = {
 		htlatex = compiler
 		,input=input
-    ,tex_file=tex_file
+        ,tex_file=tex_file
 		,packages=packages
 		,latex_par=table.concat(latex_params," ")
 		--,config=ebookutils.remove_extension(args.config)
@@ -291,6 +300,7 @@ local function process_args(args)
 		--,t4ht_dir_format=t4ht_dir_format
 	}
 	if outdir then parameters.outdir = outdir end
+	if builddir then parameters.builddir = builddir end
 	log:info("Output dir: "..outdir)
 	log:info("Compiler: "..compiler)
 	log:info("Latex options: ".. table.concat(latex_params," "))

--- a/mkutils.lua
+++ b/mkutils.lua
@@ -100,9 +100,9 @@ function parse_lg(filename, builddir)
       line:gsub("needs %-%-%- (.+)%[([0-9]+)%] ==> (.*) %-%-%-",
       function(file,page,output) 
         local rec = {
-          source = file,
+          source=file,
           page=page,
-          output = output
+          output=dir..output
         }
         table.insert(outputimages,rec)
       end

--- a/mkutils.lua
+++ b/mkutils.lua
@@ -389,7 +389,7 @@ env.Make:add("latexmk", function(par)
   par.expanded = command % par
   -- quotes in latex_command must be escaped, they cause Latexmk error
   par.expanded = par.expanded:gsub('"', '\\"')
-  local newcommand = 'latexmk  -pdf- -ps- -auxdir=. -outdir=. -latex="${expanded}" -dvi -jobname=${input} ${tex_file}' % par
+  local newcommand = 'latexmk  -pdf- -ps- -auxdir=${builddir} -outdir=${builddir} -latex="${expanded}" -dvi -jobname=${input} ${tex_file}' % par
   log:info("LaTeX call: " .. newcommand)
   os.execute(newcommand)
   return Make.testlogfile(par)

--- a/mkutils.lua
+++ b/mkutils.lua
@@ -222,10 +222,11 @@ function mkdirectories(dirs)
   if type(dirs) ~="table" then
     return false, "mkdirectories: dirs is not table"
   end
+  local path = ""
   for _,d in ipairs(dirs) do
-    local stat,msg = lfs.mkdir(d)
+    path = path .. d .. "/"
+    local stat,msg = lfs.mkdir(path)
     if not stat then return false, "makedirectories error: "..msg end
-    lfs.chdir(d)
   end
   return true
 end


### PR DESCRIPTION
By passing `--output-directory` to the TeX engine we can put its intermediate (`.aux, .toc, .log, ...`) files in a build directory. This implements the feature requested in #10.

This requires making some other functions aware that they need to look in the build directory and interpret paths relative to it.

This is a draft for now because I don't think I have gone all over the places where `make4ht` touches the  file system.

There is also some refactoring that can be done; we should have utility functions to manipulate paths etc.