### PR TITLE
Fix typo on CLI help

### DIFF
--- a/extensions/make4ht-ext-preprocess_input.lua
+++ b/extensions/make4ht-ext-preprocess_input.lua
@@ -84,7 +84,7 @@ end
 
 M.modify_build = function(make)
 
-  -- get access to the main argumens
+  -- get access to the main arguments
   local arg = make.params
   -- get the execution sequence for the input format
   local matched, msg  = get_preprocessing_pipeline(arg.tex_file)

--- a/mkparams.lua
+++ b/mkparams.lua
@@ -52,7 +52,7 @@ local function get_args(parameters, optiontext)
 	parameters.postfile = parameters.postfile or ""
 	optiontext = optiontext .. parameters.postparams ..[[  <filename> (string) Input file name
  
-Positional optional argumens:
+Positional optional arguments:
   ["tex4ht.sty op."]  Additional parameters for tex4ht.sty
   ["tex4ht op."]      Options for tex4ht command
   ["t4ht op"]         Options for t4ht command


### PR DESCRIPTION
argumens instead of argument when running --help.  Fixed it in a comment as well while at it.